### PR TITLE
Consolidate options into array

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -41,10 +41,12 @@ if (version_compare($wp_version, '3.0', '<')) {
 
 require_once(dirname(__FILE__) . '/Apache/Solr/Service.php');
 
-function s4w_get_option($option) {
+function s4w_get_option() {
     $indexall = FALSE;
+    $option = 'plugin_s4w_settings';
     if (is_multisite()) {
-        $indexall = get_site_option('s4w_index_all_sites');
+        $plugin_s4w_settings = get_site_option($option);
+        $indexall = $plugin_s4w_settings['s4w_index_all_sites'];
     }
     
     if ($indexall) {
@@ -54,10 +56,12 @@ function s4w_get_option($option) {
     }
 }
 
-function s4w_update_option($option, $optval) {
+function s4w_update_option($optval) {
     $indexall = FALSE;
+    $option = 'plugin_s4w_settings';
     if (is_multisite()) {
-        $indexall = get_site_option('s4w_index_all_sites');
+       $plugin_s4w_settings = get_site_option($option);
+       $indexall = $plugin_s4w_settings['s4w_index_all_sites'];
     }
     
     if ($indexall) {
@@ -69,9 +73,10 @@ function s4w_update_option($option, $optval) {
 
 function s4w_get_solr($ping = FALSE) {
     # get the connection options
-    $host = s4w_get_option('s4w_solr_host');
-    $port = s4w_get_option('s4w_solr_port');
-    $path = s4w_get_option('s4w_solr_path');
+    $plugin_s4w_settings = s4w_get_option();
+    $host = $plugin_s4w_settings['s4w_solr_host'];
+    $port = $plugin_s4w_settings['s4w_solr_port'];
+    $path = $plugin_s4w_settings['s4w_solr_path'];
     
     # double check everything has been set
     if ( ! ($host and $port and $path) ) {
@@ -94,10 +99,11 @@ function s4w_get_solr($ping = FALSE) {
 function s4w_build_document( $post_info, $domain = NULL, $path = NULL) {
     global $current_site, $current_blog;
     $doc = NULL;
-    $exclude_ids = s4w_get_option('s4w_exclude_pages');
-    $categoy_as_taxonomy = s4w_get_option('s4w_cat_as_taxo');
-    $index_comments = s4w_get_option('s4w_index_comments');
-    $index_custom_fields = s4w_get_option('s4w_index_custom_fields');
+    $plugin_s4w_settings = s4w_get_option();
+    $exclude_ids = $plugin_s4w_settings['s4w_exclude_pages'];
+    $categoy_as_taxonomy = $plugin_s4w_settings['s4w_cat_as_taxo'];
+    $index_comments = $plugin_s4w_settings['s4w_index_comments'];
+    $index_custom_fields = $plugin_s4w_settings['s4w_index_custom_fields'];
     
     if ($post_info) {
         
@@ -306,8 +312,9 @@ function s4w_load_blog_all($blogid) {
 function s4w_handle_modified( $post_id ) {
     global $current_blog;
     $post_info = get_post( $post_id );
-    $index_pages = s4w_get_option('s4w_index_pages');
-    $index_posts = s4w_get_option('s4w_index_posts');
+    $plugin_s4w_settings = s4w_get_option();
+    $index_pages = $plugin_s4w_settings['s4w_index_pages'];
+    $index_posts = $plugin_s4w_settings['s4w_index_posts'];
     
     if (($index_pages && $post_info->post_type == 'page') || ($index_posts && $post_info->post_type == 'post')) {
         
@@ -328,8 +335,9 @@ function s4w_handle_modified( $post_id ) {
 function s4w_handle_status_change( $post_id ) {
     global $current_blog;
     $post_info = get_post( $post_id );
-    $private_page = s4w_get_option('s4w_private_page');
-    $private_post = s4w_get_option('s4w_private_post');
+    $plugin_s4w_settings = s4w_get_option();
+    $private_page = $plugin_s4w_settings['s4w_private_page'];
+    $private_post = $plugin_s4w_settings['s4w_private_post'];
     
     if ( ($private_page && $post_info->post_type == 'page') || ($private_post && $post_info->post_type == 'post') ) {
         if ( ($_POST['prev_status'] == 'publish' || $_POST['original_post_status'] == 'publish') && 
@@ -346,8 +354,9 @@ function s4w_handle_status_change( $post_id ) {
 function s4w_handle_delete( $post_id ) {
     global $current_blog;
     $post_info = get_post( $post_id );
-    $delete_page = s4w_get_option('s4w_delete_page');
-    $delete_post = s4w_get_option('s4w_delete_post');
+    $plugin_s4w_settings = s4w_get_option();
+    $delete_page = $plugin_s4w_settings['s4w_delete_page'];
+    $delete_post = $plugin_s4w_settings['s4w_delete_post'];
     
     if ( ($delete_page && $post_info->post_type == 'page') || ($delete_post && $post_info->post_type == 'post') ) {
         if (is_multisite()) {
@@ -399,8 +408,9 @@ function s4w_load_all_posts($prev) {
     $found = FALSE;
     $end = FALSE;
     $percent = 0;
-    
-    if (is_multisite() && get_site_option('s4w_index_all_sites')) {
+    //multisite logic is decided s4w_get_option
+    $plugin_s4w_settings = s4w_get_option();
+    if ($plugin_s4w_settings['s4w_index_all_sites']) {
         $bloglist = $wpdb->get_col("SELECT * FROM {$wpdb->base_prefix}blogs", 0);
         foreach ($bloglist as $bloginfo) {
             $postids = $wpdb->get_results("SELECT ID FROM {$wpdb->base_prefix}{$bloginfo->blog_id}_posts WHERE post_status = 'publish' AND post_type = 'post' ORDER BY ID;");
@@ -483,9 +493,8 @@ function s4w_load_all_pages($prev) {
     $found = FALSE;
     $end = FALSE;
     $percent = 0;
-    
-    //if (is_multisite() && get_site_option('s4w_index_all_sites')) {
-    if (is_multisite() && FALSE) {
+    $plugin_s4w_settings = s4w_get_option();
+    if ($plugin_s4w_settings['s4w_index_all_sites']) {
         $bloglist = $wpdb->get_col("SELECT * FROM {$wpdb->base_prefix}blogs", 0);
         foreach ($bloglist as $bloginfo) {
             $postids = $wpdb->get_results("SELECT ID FROM {$wpdb->base_prefix}{$bloginfo->blog_id}_posts WHERE post_status = 'publish' AND post_type = 'page' ORDER BY ID;");
@@ -591,12 +600,13 @@ function s4w_search_results() {
     $order = $_GET['order'];
     $isdym = $_GET['isdym'];
     
-    $output_info = s4w_get_option('s4w_output_info');
-    $output_pager = s4w_get_option('s4w_output_pager');
-    $output_facets = s4w_get_option('s4w_output_facets');
-    $results_per_page = s4w_get_option('s4w_num_results');
-    $categoy_as_taxonomy = s4w_get_option('s4w_cat_as_taxo');
-    $dym_enabled = s4w_get_option('s4w_enable_dym');
+    $plugin_s4w_settings = s4w_get_option();
+    $output_info = $plugin_s4w_settings['s4w_output_info'];
+    $output_pager = $plugin_s4w_settings['s4w_output_pager'];
+    $output_facets = $plugin_s4w_settings['s4w_output_facets'];
+    $results_per_page = $plugin_s4w_settings['s4w_num_results'];
+    $categoy_as_taxonomy = $plugin_s4w_settings['s4w_cat_as_taxo'];
+    $dym_enabled = $plugin_s4w_settings['s4w_enable_dym'];
     $out = array();
     
     if ( ! $qry ) {
@@ -866,30 +876,31 @@ function s4w_query( $qry, $offset, $count, $fq, $sortby) {
     $solr = s4w_get_solr();
     $response = NULL;
     $facet_fields = array();
-    $number_of_tags = s4w_get_option('s4w_max_display_tags');
+    $plugin_s4w_settings = s4w_get_option();
+    $number_of_tags = $plugin_s4w_settings['s4w_max_display_tags'];
     
-    if (s4w_get_option('s4w_facet_on_categories')) {
+    if ($plugin_s4w_settings['s4w_facet_on_categories']) {
       $facet_fields[] = 'categories';
     }
     
-    $facet_on_tags = s4w_get_option('s4w_facet_on_tags');
+    $facet_on_tags = $plugin_s4w_settings['s4w_facet_on_tags'];
     if ($facet_on_tags) {
       $facet_fields[] = 'tags';
     }
     
-    if (s4w_get_option('s4w_facet_on_author')) {
+    if ($plugin_s4w_settings['s4w_facet_on_author']) {
       $facet_fields[] = 'author';
     }
     
-    if (s4w_get_option('s4w_facet_on_type')) {
+    if ($plugin_s4w_settings['s4w_facet_on_type']) {
       $facet_fields[] = 'type';
     }
     
-    $facet_on_custom_fields = s4w_get_option('s4w_facet_on_custom_fields');
-    if (count($facet_on_custom_fields)>0) {
-        foreach ( $facet_on_custom_fields as $field_name ) {
-        	$facet_fields[] = $field_name . '_str';
-        }
+    $facet_on_custom_fields = $plugin_s4w_settings['s4w_facet_on_custom_fields'];
+    if (is_array($facet_on_custom_fields)) {
+      foreach ( $facet_on_custom_fields as $field_name ) {
+      	$facet_fields[] = $field_name . '_str';
+      }
     }   	
     
     if ( $solr ) {
@@ -1014,7 +1025,8 @@ function s4w_add_pages() {
     $addpage = FALSE;
     
     if (is_multisite() && is_site_admin()) {
-        $indexall = get_site_option('s4w_index_all_sites');
+        $plugin_s4w_settings = s4w_get_option();
+        $indexall = $plugin_s4w_settings['s4w_index_all_sites'];
         if (($indexall && is_main_blog()) || !$indexall) {
             $addpage = TRUE;
         }

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -954,33 +954,42 @@ function s4w_options_init() {
             return;
         }
     }
-    
-    register_setting( 's4w-options-group', 's4w_solr_host', 'wp_filter_nohtml_kses' );
-    register_setting( 's4w-options-group', 's4w_solr_port', 'absint' );
-    register_setting( 's4w-options-group', 's4w_solr_path', 'wp_filter_nohtml_kses' );
-    register_setting( 's4w-options-group', 's4w_index_pages', 'absint' );
-    register_setting( 's4w-options-group', 's4w_index_posts', 'absint' );
-    register_setting( 's4w-options-group', 's4w_index_comments', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_delete_page', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_delete_post', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_private_page', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_private_post', 'absint' );
-    register_setting( 's4w-options-group', 's4w_output_info', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_output_pager', 'absint' ); 
-    register_setting( 's4w-options-group', 's4w_output_facets', 'absint' );
-    register_setting( 's4w-options-group', 's4w_exclude_pages', 's4w_filter_str2list' );
-    register_setting( 's4w-options-group', 's4w_num_results', 'absint' );
-    register_setting( 's4w-options-group', 's4w_cat_as_taxo', 'absint' );
-    register_setting( 's4w-options-group', 's4w_max_display_tags', 'absint' );
-    register_setting( 's4w-options-group', 's4w_facet_on_categories', 'absint' );
-    register_setting( 's4w-options-group', 's4w_facet_on_tags', 'absint' );
-    register_setting( 's4w-options-group', 's4w_facet_on_author', 'absint' );
-    register_setting( 's4w-options-group', 's4w_facet_on_type', 'absint' );
-    register_setting( 's4w-options-group', 's4w_index_all_sites', 'absint' );
-    register_setting( 's4w-options-group', 's4w_enable_dym', 'absint' );
-    register_setting( 's4w-options-group', 's4w_connect_type', 'wp_filter_nohtml_kses' );
-    register_setting( 's4w-options-group', 's4w_index_custom_fields', 's4w_filter_str2list' );
-    register_setting( 's4w-options-group', 's4w_facet_on_custom_fields', 's4w_filter_str2list' );    
+    register_setting('s4w-options-group', 'plugin_s4w_settings', 's4w_sanitise_options' );   
+}
+
+/**
+ * Sanitises the options values
+ * @param $options array of s4w settings options
+ * @return $options sanitised values
+ */
+function s4w_sanitise_options($options) {
+  $options['s4w_solr_host'] = wp_filter_nohtml_kses($options['s4w_solr_host']);
+  $options['s4w_solr_port'] = absint($options['s4w_solr_port']);
+  $options['s4w_solr_path'] = wp_filter_nohtml_kses($options['s4w_solr_path']);
+  $options['s4w_index_pages'] = absint($options['s4w_index_pages']);
+  $options['s4w_index_posts'] = absint($options['s4w_index_posts']);
+  $options['s4w_index_comments'] = absint($options['s4w_index_comments']); 
+  $options['s4w_delete_page'] = absint($options['s4w_delete_page']); 
+  $options['s4w_delete_post'] = absint($options['s4w_delete_post']); 
+  $options['s4w_private_page'] = absint($options['s4w_private_page']); 
+  $options['s4w_private_post'] = absint($options['s4w_private_post']);
+  $options['s4w_output_info'] = absint($options['s4w_output_info']); 
+  $options['s4w_output_pager'] = absint($options['s4w_output_pager']); 
+  $options['s4w_output_facets'] = absint($options['s4w_output_facets']);
+  $options['s4w_exclude_pages'] = s4w_filter_str2list($options['s4w_exclude_pages']);
+  $options['s4w_num_results'] = absint($options['s4w_num_results']);
+  $options['s4w_cat_as_taxo'] = absint($options['s4w_cat_as_taxo']);
+  $options['s4w_max_display_tags'] = absint($options['s4w_max_display_tags']);
+  $options['s4w_facet_on_categories'] = absint($options['s4w_facet_on_categories']);
+  $options['s4w_facet_on_tags'] = absint($options['s4w_facet_on_tags'] );
+  $options['s4w_facet_on_author'] = absint($options['s4w_facet_on_author']);
+  $options['s4w_facet_on_type'] = absint($options['s4w_facet_on_type']);
+  $options['s4w_index_all_sites'] = absint($options['s4w_index_all_sites']);
+  $options['s4w_enable_dym'] = absint($options['s4w_enable_dym'] );
+  $options['s4w_connect_type'] = wp_filter_nohtml_kses($options['s4w_connect_type']);
+  $options['s4w_index_custom_fields'] = s4w_filter_str2list($options['s4w_index_custom_fields']);
+  $options['s4w_facet_on_custom_fields'] = s4w_filter_str2list($options['s4w_facet_on_custom_fields']);    
+  return $options;
 }
 
 function s4w_filter_str2list_numeric($input) {

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -896,11 +896,20 @@ function s4w_query( $qry, $offset, $count, $fq, $sortby) {
       $facet_fields[] = 'type';
     }
     
-    $facet_on_custom_fields = $plugin_s4w_settings['s4w_facet_on_custom_fields'];
-    if (is_array($facet_on_custom_fields)) {
-      foreach ( $facet_on_custom_fields as $field_name ) {
-      	$facet_fields[] = $field_name . '_str';
+    
+    $facet_on_custom_taxonomy = $plugin_s4w_settings['s4w_facet_on_taxonomy'];
+    if (count($facet_on_custom_taxonomy)) {
+      $taxonomies = (array)get_taxonomies(array('_builtin'=>FALSE),'names');
+      foreach($taxonomies as $parent) {
+        $facet_fields[] = $parent."_taxonomy";
       }
+    }
+    
+    $facet_on_custom_fields = $plugin_s4w_settings['s4w_facet_on_custom_fields'];
+    if (count($facet_on_custom_fields)) {
+        foreach ( $facet_on_custom_fields as $field_name ) {
+        	$facet_fields[] = $field_name . '_str';
+        }
     }   	
     
     if ( $solr ) {

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -110,7 +110,7 @@ function s4w_build_document( $post_info, $domain = NULL, $path = NULL) {
         # check if we need to exclude this document
         if (is_multisite() && in_array($current_blog->domain . $current_blog->path . $post_info->ID, $exclude_ids)) {
             return NULL;
-        } else if ( !is_multisite() && in_array($post_info->ID, $exclude_ids) ) {
+        } else if ( !is_multisite() && in_array($post_info->ID, (array)$exclude_ids) ) {
             return NULL;
         }
         
@@ -192,8 +192,8 @@ function s4w_build_document( $post_info, $domain = NULL, $path = NULL) {
         }
         
         if (count($index_custom_fields)>0 && count($custom_fields = get_post_custom($post_info->ID))) {
-        	foreach ( $index_custom_fields as $field_name ) {
-          	$field = $custom_fields[$field_name];
+        	foreach ((array)$index_custom_fields as $field_name ) {
+          	$field = (array)$custom_fields[$field_name];
     				foreach ( $field as $key => $value ) {
     					$doc->addField($field_name . '_str', $value);
     					$doc->addField($field_name . '_srch', $value);

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -25,6 +25,8 @@
 $s4w_settings = s4w_get_option('plugin_s4w_settings');
 #set defaults if not initialized
 if ($s4w_settings['s4w_solr_initialized'] != 1) {
+  
+  
   $options['s4w_index_all_sites'] = 0;
   $options['s4w_solr_host'] = 'localhost';
   $options['s4w_solr_port'] = 8983;
@@ -56,11 +58,29 @@ if ($s4w_settings['s4w_solr_initialized'] != 1) {
   //$options['s4w_facet_on_custom_fields', array());
   $options['s4w_index_custom_fields'] = '';  
   $options['s4w_facet_on_custom_fields'] = '';  
-  //save our options array
+  
+  //update existing settings from multiple option record to a single array
+  //if old options exist, update to new system
+  $delte_option_function = 'delete_option';
+  if (is_multisite()) {
+    $indexall = get_site_option('s4w_index_all_sites');
+    $delte_option_function = 'delete_site_option';
+  }
+
+	foreach( $options as $key => $value ) {
+    if( $existing = get_option($key)) {
+  	  krumo( $existing);
+  		$options[$key] = $existing;
+  		delete_option($key);
+  		$indexall = FALSE;
+      $option_function($key);
+    }
+	}
+  
   $s4w_settings = $options;
+  //save our options array
   s4w_update_option($options);
 }
-
 
 wp_reset_vars(array('action'));
 

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -58,7 +58,7 @@ if ( $s4w_settings['s4w_solr_initialized'] != 1) {
     $options['s4w_index_custom_fields'] = '';  
     $options['s4w_facet_on_custom_fields'] = '';  
     //save our options array
-    s4w_update_option('plugin_s4w_settings', $options);
+    s4w_update_option($options);
 }
 wp_reset_vars(array('action'));
 
@@ -68,10 +68,8 @@ wp_reset_vars(array('action'));
 # As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
 # Lets create an array of all our options and save it once.
 if ($_POST['action'] == 'update') { 
-  krumo($_POST);
   //lets loop through our setting fields $_POST['settings']
   foreach ( $_POST['settings'] as $option => $value ) {
-    krumo($option);
     $option = trim($option);
     if ( !is_array($value) ) $value = trim($value);
     
@@ -80,7 +78,7 @@ if ($_POST['action'] == 'update') {
   
   }    
   //lets save our options array
-  s4w_update_option('plugin_s4w_settings', $_POST['settings']);
+  s4w_update_option($_POST['settings']);
 
 
   ?>

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -21,94 +21,87 @@
     THE SOFTWARE.
 */
 
-#set defaults if not initialized
-if (s4w_get_option('s4w_solr_initialized') != '1') {
-    update_site_option('s4w_index_all_sites', '0');
-    s4w_update_option('s4w_solr_host', 'localhost');
-    s4w_update_option('s4w_solr_port', '8983');
-    s4w_update_option('s4w_solr_path', '/solr');
-    s4w_update_option('s4w_index_pages', '1');
-    s4w_update_option('s4w_index_posts', '1');
-    s4w_update_option('s4w_delete_page', '1');
-    s4w_update_option('s4w_delete_post', '1');
-    s4w_update_option('s4w_private_page', '1');
-    s4w_update_option('s4w_private_post', '1');
-    s4w_update_option('s4w_output_info', '1');
-    s4w_update_option('s4w_output_pager', '1');
-    s4w_update_option('s4w_output_facets', '1');
-    //s4w_update_option('s4w_exclude_pages', array());
-    s4w_update_option('s4w_exclude_pages', '');  
-    s4w_update_option('s4w_num_results', '5');
-    s4w_update_option('s4w_cat_as_taxo', '1');
-    s4w_update_option('s4w_solr_initialized', '1');
-    s4w_update_option('s4w_max_display_tags', '10');
-    s4w_update_option('s4w_facet_on_categories', '1');
-    s4w_update_option('s4w_facet_on_taxonomy', '1');
-    s4w_update_option('s4w_facet_on_tags', '1');
-    s4w_update_option('s4w_facet_on_author', '1');
-    s4w_update_option('s4w_facet_on_type', '1');
-    s4w_update_option('s4w_enable_dym', '1');
-    s4w_update_option('s4w_index_comments', '1');
-    s4w_update_option('s4w_connect_type', 'solr');
-    //s4w_update_option('s4w_index_custom_fields', array());
-    //s4w_update_option('s4w_facet_on_custom_fields', array());
-    s4w_update_option('s4w_index_custom_fields', '');  
-    s4w_update_option('s4w_facet_on_custom_fields', '');  
-}
+//get the plugin settings
+$s4w_settings = s4w_get_option('plugin_s4w_settings');
 
+#set defaults if not initialized
+if ( $s4w_settings['s4w_solr_initialized'] != 1) {
+    $options['s4w_index_all_sites'] = 0;
+    $options['s4w_solr_host'] = 'localhost';
+    $options['s4w_solr_port'] = 8983;
+    $options['s4w_solr_path'] = '/solr';
+    $options['s4w_index_pages'] = 1;
+    $options['s4w_index_posts'] = 1;
+    $options['s4w_delete_page'] = 1;
+    $options['s4w_delete_post'] = 1;
+    $options['s4w_private_page'] = 1;
+    $options['s4w_private_post'] = 1;
+    $options['s4w_output_info'] = 1;
+    $options['s4w_output_pager'] = 1;
+    $options['s4w_output_facets'] = 1;
+    //$options['s4w_exclude_pages', array());
+    $options['s4w_exclude_pages'] = '';  
+    $options['s4w_num_results'] = 5;
+    $options['s4w_cat_as_taxo'] = 1;
+    $options['s4w_solr_initialized'] = 1;
+    $options['s4w_max_display_tags'] = 10;
+    $options['s4w_facet_on_categories'] = 1;
+    $options['s4w_facet_on_taxonomy'] = 1;
+    $options['s4w_facet_on_tags'] = 1;
+    $options['s4w_facet_on_author'] = 1;
+    $options['s4w_facet_on_type'] = 1;
+    $options['s4w_enable_dym'] = 1;
+    $options['s4w_index_comments'] = 1;
+    $options['s4w_connect_type'] = 'solr';
+    //$options['s4w_index_custom_fields', array());
+    //$options['s4w_facet_on_custom_fields', array());
+    $options['s4w_index_custom_fields'] = '';  
+    $options['s4w_facet_on_custom_fields'] = '';  
+    //save our options array
+    s4w_update_option('plugin_s4w_settings', $options);
+}
 wp_reset_vars(array('action'));
 
 # save form settings if we get the update action
 # we do saving here instead of using options.php because we need to use
 # s4w_update_option instead of update option.
-if ($_POST['action'] == 'update') {
-    $options = array('s4w_solr_host', 's4w_solr_port', 's4w_solr_path', 's4w_index_pages',
-                     's4w_index_posts', 's4w_delete_page', 's4w_delete_post', 's4w_private_page',
-                     's4w_private_post', 's4w_output_info', 's4w_output_pager', 's4w_output_facets',
-                     's4w_exclude_pages', 's4w_num_results', 's4w_cat_as_taxo', 's4w_max_display_tags',
-                     's4w_facet_on_categories', 's4w_facet_on_tags', 's4w_facet_on_author', 's4w_facet_on_type',
-                     's4w_enable_dym', 's4w_index_comments', 's4w_connect_type', 's4w_index_all_sites', 
-                     's4w_index_custom_fields', 's4w_facet_on_custom_fields', 's4w_facet_on_taxonomy');
-        
-    foreach ( $options as $option ) {
-        $option = trim($option);
-        $value = null;
-        if ( isset($_POST[$option]) )
-            $value = $_POST[$option];
-            
-        if ( !is_array($value) ) $value = trim($value);
-        $value = stripslashes_deep($value);
-        
-        if ( $option == 's4w_index_all_sites') {   
-            update_site_option($option, $value);
-        } else {
-            s4w_update_option($option, $value);
-        }
-    }
+# As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
+# Lets create an array of all our options and save it once.
+if ($_POST['action'] == 'update') { 
+  krumo($_POST);
+  //lets loop through our setting fields $_POST['settings']
+  foreach ( $_POST['settings'] as $option => $value ) {
+    krumo($option);
+    $option = trim($option);
+    if ( !is_array($value) ) $value = trim($value);
     
-    ?>
-    <div id="message" class="updated fade"><p><strong><?php _e('Success!', 'solr4wp') ?></strong></p></div>
-    <?php
+    $value = stripslashes_deep($value);
+    $option_settings[$option] = $value;
+  
+  }    
+  //lets save our options array
+  s4w_update_option('plugin_s4w_settings', $_POST['settings']);
+
+
+  ?>
+  <div id="message" class="updated fade"><p><strong><?php _e('Success!', 'solr4wp') ?></strong></p></div>
+  <?php
 }
 
 # checks if we need to check the checkbox
-function s4w_checkCheckbox( $theFieldname ) {
-    if ($theFieldname == 's4w_index_all_sites') {
-        if (get_site_option($theFieldname) == '1') {
-            echo 'checked="checked"';
-        }
-    } else {
-	    if( s4w_get_option( $theFieldname ) == '1'){
-		    echo 'checked="checked"';
-	    }
-	}
+function s4w_checkCheckbox( $fieldValue ) {
+  if( $fieldValue == '1'){
+    echo 'checked="checked"';
+  }
 }
 
-function s4w_checkConnectOption($connectType) {
-    if ( s4w_get_option('s4w_connect_type') === $connectType ) {
+function s4w_checkConnectOption($optionType, $connectType) {
+    if ( $optionType === $connectType ) {
         echo 'checked="checked"';
     }
 }
+
+
 
 # check for any POST settings
 if ($_POST['s4w_ping']) {
@@ -144,18 +137,18 @@ if ($_POST['s4w_ping']) {
 	<div class="solr_adminR">
 		<div class="solr_adminR2" id="solr_admin_tab2">
 			<label><?php _e('Solr Host', 'solr4wp') ?></label>
-			<p><input type="text" name="s4w_solr_host" value="<?php _e(s4w_get_option('s4w_solr_host'), 'solr4wp'); ?>" /></p>
+			<p><input type="text" name="settings[s4w_solr_host]" value="<?php _e($s4w_settings['s4w_solr_host'], 'solr4wp'); ?>" /></p>
 			<label><?php _e('Solr Port', 'solr4wp') ?></label>
-			<p><input type="text" name="s4w_solr_port" value="<?php _e(s4w_get_option('s4w_solr_port'), 'solr4wp'); ?>" /></p>
+			<p><input type="text" name="settings[s4w_solr_port]" value="<?php _e($s4w_settings['s4w_solr_port'], 'solr4wp'); ?>" /></p>
 			<label><?php _e('Solr Path', 'solr4wp') ?></label>
-			<p><input type="text" name="s4w_solr_path" value="<?php _e(s4w_get_option('s4w_solr_path'), 'solr4wp'); ?>" /></p>
+			<p><input type="text" name="settings[s4w_solr_path]" value="<?php _e($s4w_settings['s4w_solr_path'], 'solr4wp'); ?>" /></p>
 		</div>
 	</div>
 	<ol>
 		<li id="solr_admin_tab1_btn" class="solr_admin_tab1">
 		</li>
 		<li id="solr_admin_tab2_btn" class="solr_admin_tab2">
-			<h4><input id="solrconnect" name="s4w_connect_type" type="radio" value="solr" <?php s4w_checkConnectOption('solr'); ?> onclick="switch1();" />Solr Server</h4>
+			<h4><input id="solrconnect" name="settings[s4w_connect_type]" type="radio" value="solr" <?php s4w_checkConnectOption($s4w_settings['s4w_connect_type'], 'solr'); ?> onclick="switch1();" />Solr Server</h4>
 			<ol>
 				<li>Download, install and configure your own <a href="">Apache Solr 1.4</a> instance</li>
 			</ol>
@@ -167,28 +160,28 @@ if ($_POST['s4w_ping']) {
 <table class="form-table">
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Index Pages', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_index_pages" value="1" <?php echo s4w_checkCheckbox('s4w_index_pages'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_index_pages]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_index_pages']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Index Posts', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_index_posts" value="1" <?php echo s4w_checkCheckbox('s4w_index_posts'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_index_posts]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_index_posts']); ?> /></td>
     </tr>
 
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Remove Page on Delete', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_delete_page" value="1" <?php echo s4w_checkCheckbox('s4w_delete_page'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_delete_page]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_delete_page']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Remove Post on Delete', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_delete_post" value="1" <?php echo s4w_checkCheckbox('s4w_delete_post'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_delete_post]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_delete_post']); ?> /></td>
     </tr>
     
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Remove Page on Status Change', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_private_page" value="1" <?php echo s4w_checkCheckbox('s4w_private_page'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_private_page]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_private_page']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Remove Post on Status Change', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_private_post" value="1" <?php echo s4w_checkCheckbox('s4w_private_post'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_private_post]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_private_post']); ?> /></td>
     </tr>
 
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Index Comments', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_index_comments" value="1" <?php echo s4w_checkCheckbox('s4w_index_comments'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_index_comments]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_index_comments']); ?> /></td>
     </tr>
         
     <?php
@@ -198,18 +191,18 @@ if ($_POST['s4w_ping']) {
     
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Index all Sites', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_index_all_sites" value="1" <?php echo s4w_checkCheckbox('s4w_index_all_sites'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_index_all_sites]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_index_all_sites']); ?> /></td>
     </tr>
     <?php
     }
     ?>
     <tr valign="top">
         <th scope="row"><?php _e('Index custom fields (comma separated names list)') ?></th>
-        <td><input type="text" name="s4w_index_custom_fields" value="<?php print( s4w_filter_list2str(s4w_get_option('s4w_index_custom_fields'), 'solr4wp')); ?>" /></td>
+        <td><input type="text" name="settings[s4w_index_custom_fields]" value="<?php print( s4w_filter_list2str($s4w_settings['s4w_index_custom_fields'], 'solr4wp')); ?>" /></td>
     </tr>
     <tr valign="top">
         <th scope="row"><?php _e('Excludes Posts or Pages (comma separated ids list)') ?></th>
-        <td><input type="text" name="s4w_exclude_pages" value="<?php print( s4w_filter_list2str(s4w_get_option('s4w_exclude_pages'), 'solr4wp')); ?>" /></td>
+        <td><input type="text" name="settings[s4w_exclude_pages]" value="<?php print( s4w_filter_list2str($s4w_settings['s4w_exclude_pages'], 'solr4wp')); ?>" /></td>
     </tr>
 </table>
 <hr />
@@ -217,55 +210,55 @@ if ($_POST['s4w_ping']) {
 <table class="form-table">
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Output Result Info', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_output_info" value="1" <?php echo s4w_checkCheckbox('s4w_output_info'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_output_info]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_output_info']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Output Result Pager', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_output_pager" value="1" <?php echo s4w_checkCheckbox('s4w_output_pager'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_output_pager]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_output_pager']); ?> /></td>
     </tr>
  
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Output Facets', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_output_facets" value="1" <?php echo s4w_checkCheckbox('s4w_output_facets'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_output_facets]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_output_facets']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Category Facet as Taxonomy', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_cat_as_taxo" value="1" <?php echo s4w_checkCheckbox('s4w_cat_as_taxo'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_cat_as_taxo]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_cat_as_taxo']); ?> /></td>
     </tr>
 
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Categories as Facet', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_facet_on_categories" value="1" <?php echo s4w_checkCheckbox('s4w_facet_on_categories'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_facet_on_categories]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_facet_on_categories']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Tags as Facet', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_facet_on_tags" value="1" <?php echo s4w_checkCheckbox('s4w_facet_on_tags'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_facet_on_tags]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_facet_on_tags']); ?> /></td>
     </tr>
     
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Author as Facet', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_facet_on_author" value="1" <?php echo s4w_checkCheckbox('s4w_facet_on_author'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_facet_on_author]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_facet_on_author']); ?> /></td>
         <th scope="row" style="width:200px;float:left;margin-left:20px;"><?php _e('Type as Facet', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_facet_on_type" value="1" <?php echo s4w_checkCheckbox('s4w_facet_on_type'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_facet_on_type]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_facet_on_type']); ?> /></td>
     </tr>
 
      <tr valign="top">
          <th scope="row" style="width:200px;"><?php _e('Taxonomy as Facet', 'solr4wp') ?></th>
-         <td style="width:10px;float:left;"><input type="checkbox" name="s4w_facet_on_taxonomy" value="1" <?php echo s4w_checkCheckbox('s4w_facet_on_taxonomy'); ?> /></td>
+         <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_facet_on_taxonomy]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_facet_on_taxonomy']); ?> /></td>
       </tr>
       
     <tr valign="top">
         <th scope="row"><?php _e('Custom fields as Facet (comma separated ordered names list)') ?></th>
-        <td><input type="text" name="s4w_facet_on_custom_fields" value="<?php print( s4w_filter_list2str(s4w_get_option('s4w_facet_on_custom_fields'), 'solr4wp')); ?>" /></td>
+        <td><input type="text" name="settings[s4w_facet_on_custom_fields]" value="<?php print( s4w_filter_list2str($s4w_settings['s4w_facet_on_custom_fields'], 'solr4wp')); ?>" /></td>
     </tr>
 
     <tr valign="top">
         <th scope="row" style="width:200px;"><?php _e('Enable Spellchecking', 'solr4wp') ?></th>
-        <td style="width:10px;float:left;"><input type="checkbox" name="s4w_enable_dym" value="1" <?php echo s4w_checkCheckbox('s4w_enable_dym'); ?> /></td>
+        <td style="width:10px;float:left;"><input type="checkbox" name="settings[s4w_enable_dym]" value="1" <?php echo s4w_checkCheckbox($s4w_settings['s4w_enable_dym']); ?> /></td>
     </tr>
                    
     <tr valign="top">
         <th scope="row"><?php _e('Number of Results Per Page', 'solr4wp') ?></th>
-        <td><input type="text" name="s4w_num_results" value="<?php _e(s4w_get_option('s4w_num_results'), 'solr4wp'); ?>" /></td>
+        <td><input type="text" name="settings[s4w_num_results]" value="<?php _e($s4w_settings['s4w_num_results'], 'solr4wp'); ?>" /></td>
     </tr>   
     
     <tr valign="top">
         <th scope="row"><?php _e('Max Number of Tags to Display', 'solr4wp') ?></th>
-        <td><input type="text" name="s4w_max_display_tags" value="<?php _e(s4w_get_option('s4w_max_display_tags'), 'solr4wp'); ?>" /></td>
+        <td><input type="text" name="settings[s4w_max_display_tags]" value="<?php _e($s4w_settings['s4w_max_display_tags'], 'solr4wp'); ?>" /></td>
     </tr>
 </table>
 <hr />

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -23,43 +23,45 @@
 
 //get the plugin settings
 $s4w_settings = s4w_get_option('plugin_s4w_settings');
-
 #set defaults if not initialized
-if ( $s4w_settings['s4w_solr_initialized'] != 1) {
-    $options['s4w_index_all_sites'] = 0;
-    $options['s4w_solr_host'] = 'localhost';
-    $options['s4w_solr_port'] = 8983;
-    $options['s4w_solr_path'] = '/solr';
-    $options['s4w_index_pages'] = 1;
-    $options['s4w_index_posts'] = 1;
-    $options['s4w_delete_page'] = 1;
-    $options['s4w_delete_post'] = 1;
-    $options['s4w_private_page'] = 1;
-    $options['s4w_private_post'] = 1;
-    $options['s4w_output_info'] = 1;
-    $options['s4w_output_pager'] = 1;
-    $options['s4w_output_facets'] = 1;
-    //$options['s4w_exclude_pages', array());
-    $options['s4w_exclude_pages'] = '';  
-    $options['s4w_num_results'] = 5;
-    $options['s4w_cat_as_taxo'] = 1;
-    $options['s4w_solr_initialized'] = 1;
-    $options['s4w_max_display_tags'] = 10;
-    $options['s4w_facet_on_categories'] = 1;
-    $options['s4w_facet_on_taxonomy'] = 1;
-    $options['s4w_facet_on_tags'] = 1;
-    $options['s4w_facet_on_author'] = 1;
-    $options['s4w_facet_on_type'] = 1;
-    $options['s4w_enable_dym'] = 1;
-    $options['s4w_index_comments'] = 1;
-    $options['s4w_connect_type'] = 'solr';
-    //$options['s4w_index_custom_fields', array());
-    //$options['s4w_facet_on_custom_fields', array());
-    $options['s4w_index_custom_fields'] = '';  
-    $options['s4w_facet_on_custom_fields'] = '';  
-    //save our options array
-    s4w_update_option($options);
+if ($s4w_settings['s4w_solr_initialized'] != 1) {
+  $options['s4w_index_all_sites'] = 0;
+  $options['s4w_solr_host'] = 'localhost';
+  $options['s4w_solr_port'] = 8983;
+  $options['s4w_solr_path'] = '/solr';
+  $options['s4w_index_pages'] = 1;
+  $options['s4w_index_posts'] = 1;
+  $options['s4w_delete_page'] = 1;
+  $options['s4w_delete_post'] = 1;
+  $options['s4w_private_page'] = 1;
+  $options['s4w_private_post'] = 1;
+  $options['s4w_output_info'] = 1;
+  $options['s4w_output_pager'] = 1;
+  $options['s4w_output_facets'] = 1;
+  //$options['s4w_exclude_pages', array());
+  $options['s4w_exclude_pages'] = '';  
+  $options['s4w_num_results'] = 5;
+  $options['s4w_cat_as_taxo'] = 1;
+  $options['s4w_solr_initialized'] = 1;
+  $options['s4w_max_display_tags'] = 10;
+  $options['s4w_facet_on_categories'] = 1;
+  $options['s4w_facet_on_taxonomy'] = 1;
+  $options['s4w_facet_on_tags'] = 1;
+  $options['s4w_facet_on_author'] = 1;
+  $options['s4w_facet_on_type'] = 1;
+  $options['s4w_enable_dym'] = 1;
+  $options['s4w_index_comments'] = 1;
+  $options['s4w_connect_type'] = 'solr';
+  //$options['s4w_index_custom_fields', array());
+  //$options['s4w_facet_on_custom_fields', array());
+  $options['s4w_index_custom_fields'] = '';  
+  $options['s4w_facet_on_custom_fields'] = '';  
+  //save our options array
+  $s4w_settings = $options;
+  s4w_update_option($options);
 }
+
+
 wp_reset_vars(array('action'));
 
 # save form settings if we get the update action
@@ -67,18 +69,17 @@ wp_reset_vars(array('action'));
 # s4w_update_option instead of update option.
 # As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
 # Lets create an array of all our options and save it once.
-if ($_POST['action'] == 'update') { 
+if ($_POST['action'] == 'update') {   
   //lets loop through our setting fields $_POST['settings']
-  foreach ( $_POST['settings'] as $option => $value ) {
-    $option = trim($option);
-    if ( !is_array($value) ) $value = trim($value);
-    
+  foreach ($s4w_settings as $option => $old_value ) {
+    $value = $_POST['settings'][$option];
+    if ($option == 's4w_index_all_sites' || $option == 's4w_solr_initialized') $value = trim($old_value);  
+    if ( !is_array($value) ) $value = trim($value); 
     $value = stripslashes_deep($value);
-    $option_settings[$option] = $value;
-  
+    $s4w_settings[$option] = $value;
   }    
   //lets save our options array
-  s4w_update_option($_POST['settings']);
+  s4w_update_option($s4w_settings);
 
 
   ?>

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -58,7 +58,7 @@ if ( $s4w_settings['s4w_solr_initialized'] != 1) {
     $options['s4w_index_custom_fields'] = '';  
     $options['s4w_facet_on_custom_fields'] = '';  
     //save our options array
-    s4w_update_option('plugin_s4w_settings', $options);
+    s4w_update_option($options);
 }
 wp_reset_vars(array('action'));
 
@@ -68,7 +68,6 @@ wp_reset_vars(array('action'));
 # As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
 # Lets create an array of all our options and save it once.
 if ($_POST['action'] == 'update') { 
-  krumo($_POST);
   //lets loop through our setting fields $_POST['settings']
   foreach ( $_POST['settings'] as $option => $value ) {
     krumo($option);
@@ -80,7 +79,7 @@ if ($_POST['action'] == 'update') {
   
   }    
   //lets save our options array
-  s4w_update_option('plugin_s4w_settings', $_POST['settings']);
+  s4w_update_option($_POST['settings']);
 
 
   ?>


### PR DESCRIPTION
I have branched out for this since it required some extensive changes to the way we call the options value.

Consolidated our options into an array so that we only make one call when using get_options/update_options

It is backward compatible and will on being run try to update the old options records to the new format.

I have tested on both vanilla install and an old install... would appreciate some further testing

but seems good to go from where i understand (feedback appreciated)
