### PR TITLE
Fixes issue preventing a user from setting up a single solr server instance

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -732,7 +732,9 @@ function s4w_search_results() {
                         $offsetnum = ($pagenum - 1) * $count;
                         $pageritm = array();
                         $pageritm['page'] = sprintf(__("%d"), $pagenum);
-                        $pageritm['link'] = htmlspecialchars(sprintf(__("?s=%s&offset=%d&count=%d"), urlencode($qry), $offsetnum, $count));
+                        $pagerlink = sprintf(__("?s=%s&offset=%d&count=%d"), urlencode($qry), $offsetnum, $count);
+                        if($fqstr) $pagerlink .= '&fq=' . $fqstr;
+                        $pageritm['link'] = htmlspecialchars($pagerlink);
                         //if server is set add it on the end of the url
                         $selectedfacet['removelink'] .=$serverval;
                         $pagerout[] = $pageritm;

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -732,9 +732,7 @@ function s4w_search_results() {
                         $offsetnum = ($pagenum - 1) * $count;
                         $pageritm = array();
                         $pageritm['page'] = sprintf(__("%d"), $pagenum);
-                        $pagerlink = sprintf(__("?s=%s&offset=%d&count=%d"), urlencode($qry), $offsetnum, $count);
-                        if($fqstr) $pagerlink .= '&fq=' . $fqstr;
-                        $pageritm['link'] = htmlspecialchars($pagerlink);
+                        $pageritm['link'] = htmlspecialchars(sprintf(__("?s=%s&offset=%d&count=%d"), urlencode($qry), $offsetnum, $count));
                         //if server is set add it on the end of the url
                         $selectedfacet['removelink'] .=$serverval;
                         $pagerout[] = $pageritm;

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -69,14 +69,14 @@ if ($s4w_settings['s4w_solr_initialized'] != 1) {
   }
   //find each of the old options function
   //update our new array and delete the record.
-	foreach($options as $key => $value ) {
+  foreach($options as $key => $value ) {
     if( $existing = get_option($key)) {
-  		$options[$key] = $existing;
-  		$indexall = FALSE;
-  		//run the appropriate delete options function
+      $options[$key] = $existing;
+      $indexall = FALSE;
+      //run the appropriate delete options function
       $delete_option_function($key);
     }
-	}
+  }
   
   $s4w_settings = $options;
   //save our options array
@@ -91,14 +91,15 @@ wp_reset_vars(array('action'));
 # As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
 # Lets create an array of all our options and save it once.
 if ($_POST['action'] == 'update') {   
+print_r($_POST);
   //lets loop through our setting fields $_POST['settings']
   foreach ($s4w_settings as $option => $old_value ) {
     $value = $_POST['settings'][$option];
-    
+
     switch ($option) {
       case 's4w_index_all_sites':
       case 's4w_solr_initialized':
-        $value = trim($old_value);
+        $value = trim($value);
         break;
     case 's4w_server':
       //remove empty server entries
@@ -112,7 +113,6 @@ if ($_POST['action'] == 'update') {
 
     }
     if ( !is_array($value) ) $value = trim($value); 
-
     $value = stripslashes_deep($value);
     $s4w_settings[$option] = $value;
   }

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -91,7 +91,6 @@ wp_reset_vars(array('action'));
 # As it stands we have 27 options instead of making 27 insert calls (which is what update_options does)
 # Lets create an array of all our options and save it once.
 if ($_POST['action'] == 'update') {   
-print_r($_POST);
   //lets loop through our setting fields $_POST['settings']
   foreach ($s4w_settings as $option => $old_value ) {
     $value = $_POST['settings'][$option];

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -96,9 +96,8 @@ if ($_POST['action'] == 'update') {
     $value = $_POST['settings'][$option];
 
     switch ($option) {
-      case 's4w_index_all_sites':
       case 's4w_solr_initialized':
-        $value = trim($value);
+        $value = trim($old_value);
         break;
     case 's4w_server':
       //remove empty server entries

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -123,10 +123,10 @@ if ($_POST['action'] == 'update') {
   //lets save our options array
   s4w_update_option($s4w_settings);
 
- //we need to make call for the options again 
- //as we need them to come out in an a sanitised format
- //otherwise fields that need to run s4w_filter_list2str will come up with nothin
- $s4w_settings = s4w_get_option('plugin_s4w_settings');
+  //we need to make call for the options again 
+  //as we need them to come out in an a sanitised format
+  //otherwise fields that need to run s4w_filter_list2str will come up with nothin
+  $s4w_settings = s4w_get_option('plugin_s4w_settings');
 
   ?>
   <div id="message" class="updated fade"><p><strong><?php _e('Success!', 'solr4wp') ?></strong></p></div>


### PR DESCRIPTION
The form fields for the single server section of the setup screen were being clobbered by the multi server setup.  This resolves that issue.  Ignore my merge/revert, you'll see they change no files.
