### PR TITLE
Fix batch import

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -434,11 +434,8 @@ function s4w_load_all_posts($prev) {
     $blog_id = $blog->blog_id;
     if ($plugin_s4w_settings['s4w_index_all_sites']) {
 
-        // this *will* require a lot of memory to get done, particularly
-        // for blogs with a lot of posts so we do a nasty hack
-        // and increase allowed memory here, hope your host can handle it :)
-        syslog(LOG_ERR,"starting batch import, setting memory limit to 3GB, setting max execution time to unlimited"); 
-        ini_set('memory_limit', '3072M');
+        // there is potential for this to run for an extended period of time, depending on the # of blgos
+        syslog(LOG_ERR,"starting batch import, setting max execution time to unlimited"); 
         set_time_limit(0);
 
         // get a list of blog ids
@@ -453,6 +450,10 @@ function s4w_load_all_posts($prev) {
 
             // attempt to save some memory by flushing wordpress's cache
             wp_cache_flush();
+
+            // everything just works better if we tell wordpress
+            // to switch to the blog we're using, this is a multi-site
+            // specific function
             switch_to_blog($blog_id);
 
             // now we actually gather the blog posts
@@ -476,6 +477,8 @@ function s4w_load_all_posts($prev) {
                     $end = TRUE;
                 }
                 
+                // using wpurl is better because it will return the proper
+                // URL for the blog whether it is a subdomain install or otherwise
                 $documents[] = s4w_build_document( get_blog_post($blog_id, $postid), substr(get_bloginfo('wpurl'),7), $current_site->path );
                 $cnt++;
                 if ($cnt == $batchsize) {

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1214,6 +1214,7 @@ function s4w_admin_head() {
     function disableAll() {
         $j('[name=s4w_postload]').attr('disabled','disabled');
         $j('[name=s4w_deleteall]').attr('disabled','disabled');
+        $j('[name=s4w_init_blogs]').attr('disabled','disabled');
         $j('[name=s4w_optimize]').attr('disabled','disabled');
         $j('[name=s4w_pageload]').attr('disabled','disabled');
         $j('[name=s4w_ping]').attr('disabled','disabled');
@@ -1223,6 +1224,7 @@ function s4w_admin_head() {
     function enableAll() {
         $j('[name=s4w_postload]').removeAttr('disabled');
         $j('[name=s4w_deleteall]').removeAttr('disabled');
+        $j('[name=s4w_init_blogs]').removeAttr('disabled');
         $j('[name=s4w_optimize]').removeAttr('disabled');
         $j('[name=s4w_pageload]').removeAttr('disabled');
         $j('[name=s4w_ping]').removeAttr('disabled');

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -176,7 +176,10 @@ if ($_POST['s4w_ping']) {
 ?>
     <div id="message" class="updated fade"><p><strong><?php _e('Index Optimized!', 'solr4wp') ?></strong></p></div>
 <?php
-}
+} else if ($_POST['s4w_init_blogs']) {
+    s4w_copy_config_to_all_blogs();
+  }  ?>
+        <div id="message" class="updated fade"><p><strong><?php _e('Solr for Wordpress Configured for All Blogs!', 'solr4wp') ?></strong></p></div>
 ?>
 
 <div class="wrap">
@@ -370,6 +373,14 @@ if ($_POST['s4w_ping']) {
         <th scope="row"><?php _e('Check Server Settings', 'solr4wp') ?></th>
         <td><input type="submit" class="button-primary" name="s4w_ping" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
     </tr>
+
+    <?php if(is_multisite()) { ?>
+    <tr valign="top">
+        <th scope="row"><?php _e('Push Solr Configuration to All Blogs', 'solr4wp') ?></th>
+        <td><input type="submit" class="button-primary" name="s4w_init_blogs" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
+    </tr>
+    <?php } ?>
+    
  
     <tr valign="top">
         <th scope="row"><?php _e('Load All Pages', 'solr4wp') ?></th>


### PR DESCRIPTION
These commits fixes up the ability to batch import blog posts when using wordpress in a multi user/site environment.  It does so by modifying the Load All Posts in a way that ensures entries are pulled correctly for each registered blog that isn't marked as spam or as deleted.  

It also adds a new option to push the solr for wordpress config from the current blog (which should be the top level blog or blog 1) and pushes it to all registered blogs also not marked as spam or as deleted.

While this fixes the batch import, it has yet to solve why, even if the plugin is network activated, new posts aren't indexed and new blogs don't inherit the correct settings.
