### PR TITLE
import related things (memory limit, encoding issues and stray ?> in admin panel)

### DIFF
--- a/SolrPhpClient/Apache/Solr/Service.php
+++ b/SolrPhpClient/Apache/Solr/Service.php
@@ -767,7 +767,7 @@ class Apache_Solr_Service
 						// only set the boost for the first field in the set
 						$fieldBoost = false;
 					}
-
+					$multivalue = utf8_encode($multivalue);
 					$multivalue = htmlspecialchars($multivalue, ENT_NOQUOTES, 'UTF-8');
 
 					$xml .= '>' . $multivalue . '</field>';

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -315,7 +315,7 @@ function s4w_load_blog_all($blogid) {
     $batchsize = 10;
     
     $bloginfo = get_blog_details($blogid, FALSE);
-    
+   
     if ($bloginfo->public && !$bloginfo->archived && !$bloginfo->spam && !$bloginfo->deleted) {
         $postids = $wpdb->get_results("SELECT ID FROM {$wpdb->base_prefix}{$blogid}_posts WHERE post_status = 'publish';");
         for ($idx = 0; $idx < count($postids); $idx++) {
@@ -447,7 +447,7 @@ function s4w_load_all_posts($prev) {
     global $wpdb, $current_blog, $current_site;
     $documents = array();
     $cnt = 0;
-    $batchsize = 1000;
+    $batchsize = 250;
     $last = "";
     $found = FALSE;
     $end = FALSE;
@@ -536,20 +536,19 @@ function s4w_load_all_posts($prev) {
                 if ($postid === $prev) {
                     $found = TRUE;
                 }
-                
                 continue;
             }
             
             if ($idx === $postcount - 1) {
                 $end = TRUE;
             }
-            
             $documents[] = s4w_build_document( get_post($postid) );
             $cnt++;
             if ($cnt == $batchsize) {
                 s4w_post( $documents, FALSE, FALSE);
                 $cnt = 0;
                 $documents = array();
+                wp_cache_flush();
                 break;
             }
         }

--- a/solr-options-page.php
+++ b/solr-options-page.php
@@ -180,7 +180,7 @@ if ($_POST['s4w_ping']) {
     s4w_copy_config_to_all_blogs();
   }  ?>
         <div id="message" class="updated fade"><p><strong><?php _e('Solr for Wordpress Configured for All Blogs!', 'solr4wp') ?></strong></p></div>
-?>
+
 
 <div class="wrap">
 <h2><?php _e('Solr For WordPress', 'solr4wp') ?></h2>


### PR DESCRIPTION
1. Fix stray ?> in the admin options page.
2. Reduce batch size and try and avoid memory limit problems when performing an import on a wordpress 3.1 blog (I'm not sure if the wp_cache_flush() is what solved it, or reducing the batch size from 1000 to 250). Regardless, the combination did work. I remain mystified as to why this server didn't accept me increasing the memory limit to 4gb (Which would have fixed the problem) and instead insisted on failing at 256mb .... nevermind.

Error seen :
[01-Dec-2011 00:31:05] PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 71 bytes) in /xxxxxx/httpdocs/wp-content/plugins/solr-for-wordpress/SolrPhpClient/Apache/Solr/Document.php on line 179
1. Fix/workaround dodgy data on import -

Error seen:
[01-Dec-2011 00:48:38] PHP Warning:  htmlspecialchars() [<a href='function.htmlspecialchars'>function.htmlspecialchars</a>]: Invalid multibyte sequence in argument in /xxxxxx/httpdocs/wp-content/plugins/solr-for-wordpress/SolrPhpClient/Apache/Solr/Service.php on line 785

Passing data through utf8_encode() appears to solve the problem. It's possible this is a problem unique to this site; but this fixes it for me. Note, I'm stuck on PHP5.2.6 - newer versions of PHP/htmlspecialchars have additional options which would probably solve this, but I can't use.

thanks
David.
