### PR TITLE
updated template loading

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1250,10 +1250,10 @@ function s4w_template_redirect() {
         exit;
     }
     
-    // If there is a template file then we use it
-    if (file_exists(TEMPLATEPATH . '/s4w_search.php')) {
+	// If there is a template file then we use it
+    if (locate_template( array( 's4w_search' ), FALSE, TRUE)) {
         // use theme file
-        include_once(TEMPLATEPATH . '/s4w_search.php');
+        locate_template( array( 's4w_search' ), FALSE, TRUE);
     } else if (file_exists(dirname(__FILE__) . '/template/s4w_search.php')) {
         // use plugin supplied file
         add_action('wp_head', 's4w_default_head');

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1253,7 +1253,7 @@ function s4w_template_redirect() {
 	// If there is a template file then we use it
     if (locate_template( array( 's4w_search' ), FALSE, TRUE)) {
         // use theme file
-        locate_template( array( 's4w_search' ), FALSE, TRUE);
+        locate_template( array( 's4w_search' ), TRUE, TRUE);
     } else if (file_exists(dirname(__FILE__) . '/template/s4w_search.php')) {
         // use plugin supplied file
         add_action('wp_head', 's4w_default_head');


### PR DESCRIPTION
I adjusted the template loading feature located on line 1253 to use the WordPress locate_template function instead of the TEMPLATEPATH constant as locate_template supports child themes, where the TEMPLATE path constant does not. This allows for a BuddyPress site to use the normal theme structure of a child theme instead of needing to place a template file in the BuddyPress plugin directory. This would also affect anyone building a child theme of the standard WordPress themes and certain frameworks etc.

Example:
output of TEMPLATEPATH in a BuddyPress site would be similar to: <pre>/var/www/wp-content/plugins/buddypress/bp-themes/bp-default</pre>

Where in most cases a theme developer would be building a theme sourced from <pre>/var/www/wp-content/themes/my-cool-theme</pre>

Thanks!
