### PR TITLE
don't substr the site_url, could be using https

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -128,7 +128,7 @@ function s4w_build_document( $post_info, $domain = NULL, $path = NULL) {
     if ($post_info) {
         
         # check if we need to exclude this document
-        if (is_multisite() && in_array(substr(site_url(),7) . $post_info->ID, (array)$exclude_ids)) {
+        if (is_multisite() && in_array($current_blog->domain . $post_info->ID, (array)$exclude_ids)) {
             return NULL;
         } else if ( !is_multisite() && in_array($post_info->ID, (array)$exclude_ids) ) {
             return NULL;


### PR DESCRIPTION
When building the document exclusion list the domain is generated using substr of the site_url.  This assumes that the site is only running under http, this might not be try.  Uses $current_blog->domain instead
