### PR TITLE
Allow for child themes to override s4w_search.php

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1262,9 +1262,9 @@ function s4w_template_redirect() {
     }
     
     // If there is a template file then we use it
-    if (file_exists(TEMPLATEPATH . '/s4w_search.php')) {
+    if (file_exists(STYLESHEETPATH . '/s4w_search.php')) {
         // use theme file
-        include_once(TEMPLATEPATH . '/s4w_search.php');
+        include_once(STYLESHEETPATH . '/s4w_search.php');
     } else if (file_exists(dirname(__FILE__) . '/template/s4w_search.php')) {
         // use plugin supplied file
         add_action('wp_head', 's4w_default_head');


### PR DESCRIPTION
Allow for the s4w_search.php to be used for a child theme. To do this we should use the STYLESHEETPATH global rather than the THEMEPATH.
