### PR TITLE
Hide error in Autocomplete and enhanced custom post type handling

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1406,18 +1406,18 @@ function s4w_autocomplete($q, $limit) {
     $params['terms.limit'] = $limit;
     $params['qt'] = '/terms';
 
-    $response = $solr->search($q, 0, $limit, $params);
-    if ( ! $response->getHttpStatus() == 200 ) {
-        return;
-    }
+    try {
+        $response = $solr->search($q, 0, $limit, $params);
+        if ( ! $response->getHttpStatus() == 200 || empty($response->terms)) {
+            return;
+        }
 
-    if ( empty($response->terms) ) {
-        return;
-    }
-
-    $terms = get_object_vars($response->terms->spell);
-    foreach($terms as $term => $count) {
-        printf("%s\n", $term);
+        $terms = get_object_vars($response->terms->spell);
+        foreach($terms as $term => $count) {
+            printf("%s\n", $term);
+        }
+    } catch (Apache_Solr_HttpTransportException $e) {
+        error_log('An exception occurred attempting to use SOLR autocomplete: ' . $e->getMessage());
     }
 }
 

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1407,10 +1407,14 @@ function s4w_autocomplete($q, $limit) {
     $params['qt'] = '/terms';
 
     $response = $solr->search($q, 0, $limit, $params);
-    if ( ! $response->getHttpStatus() == 200 ) { 
+    if ( ! $response->getHttpStatus() == 200 ) {
         return;
     }
-    
+
+    if ( empty($response->terms) ) {
+        return;
+    }
+
     $terms = get_object_vars($response->terms->spell);
     foreach($terms as $term => $count) {
         printf("%s\n", $term);

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1459,16 +1459,10 @@ function s4w_apply_config_to_blog($blogid) {
  * @return array
  */
 function s4w_get_all_post_types() {
-  global $wpdb;
-  //remove the defualt attachment/revision and menu from the returned types.
-  $query = $wpdb->get_results("SELECT DISTINCT(post_type) FROM $wpdb->posts WHERE post_type NOT IN('attachment', 'revision', 'nav_menu_item') ORDER BY post_type");
-  if ($query) {
-    $types = array();
-    foreach ( $query as $type ) {
-      $types[] = $type->post_type;
-    }       
-    return $types;
-  }
+  //remove the default attachment/revision and menu from the returned types.
+  $posts = get_post_types( array('public' => true) );
+  $posts = array_diff($posts, array('attachment', 'revision', 'nav_menu_item'));
+  return $posts;
 }
 
 add_action( 'template_redirect', 's4w_template_redirect', 1 );

--- a/template/search.css
+++ b/template/search.css
@@ -1,234 +1,220 @@
-#content {
-	width: auto !important;
-}
-
-*+ html clearfix {
-	display: inline-block !important;
-}
-*+ html ul,ol {
-	list-style-position: outside !important;
-}
-
-
 .solr * {
-	line-height: 1 !important;
-	padding: 0 !important;
-	margin: 0 !important;
-	text-align: left !important;
+	line-height: 1;
+	padding: 0;
+	margin: 0;
+	text-align: left;
 }
 .solr ol, .solr ul, .solr ol li, .solr ul li {
-	background: none !important;
-	list-style-type: none !important;
-	overflow: hidden !important; /* IE7 */
+	background: none;
+	list-style-type: none;
+	overflow: hidden; /* IE7 */
 }
-.solr h2 {font-size:16px !important;}
-.solr h3 {font-size:14px !important;}
+.solr h2 {font-size:16px;}
+.solr h3 {font-size:14px;}
 .solr {
-	font-size: 12px !important;
-	line-height: 1 !important;
-	margin: 0 !important;
-	padding: 20px !important;
-	width: auto !important;
+	font-size: 12px;
+	line-height: 1;
+	margin: 0;
+	padding: 20px;
+	width: auto;
 }
 div.solr1 {
-	border-bottom: 1px solid #cccccc !important;
-	padding: 0 0 6px !important;
+	border-bottom: 1px solid #cccccc;
 }
 div.solr_search {
-	clear: both !important;
-	padding: 0 0 12px !important;
+	clear: both;
+	padding: 0 0 12px;
 }
 div.solr_search input {
-	font-size: 18px !important;
+	font-size: 18px;
 }
 .solr_field {
-	border: 1px solid #b7b7b7 !important;
-	border-top: 2px solid #999999 !important;
-	padding: 3px !important;
-	margin: 0 8px 0 0 !important;
-	width: 330px !important;
+	border: 1px solid #b7b7b7;
+	border-top: 2px solid #999999;
+	padding: 3px;
+	margin: 0 8px 0 0;
+	width: 330px;
 }
 ol.solr_auto {
-	background: #ffffff !important;
-	border: 1px solid #b7b7b7 !important;
-	width: 336px !important;
-	padding: 6px 0 !important;
-	position: absolute !important;
-	clear: both !important; /* IE6 */
-	z-index: 100 !important;
+	background: #ffffff;
+	border: 1px solid #b7b7b7;
+	width: 336px;
+	padding: 6px 0;
+	position: absolute;
+	clear: both; /* IE6 */
+	z-index: 100;
 }
 .solr_auto li {
-	padding: 2px 8px !important;
+	padding: 2px 8px;
 }
 .solr_auto li:hover {
-	background: #efffb0 !important;
+	background: #efffb0;
 }
 div.solr_suggest {
-	padding: 0 0 5px !important;
+	padding: 0 0 5px;
 }
 label.solr_response {
-	font-size: 10px !important;
-	color: #666666 !important;
-	float: right !important;
-	position: relative !important;
-	top: 13px !important;
+	font-size: 10px;
+	color: #666666;
+	float: right;
+	position: relative;
+	top: 13px;
 }
 div.solr3 {
-	float: left !important;
-	padding: 18px 2% 0 0 !important;
-	width: 23% !important;
+	float: left;
+	padding: 18px 2% 0 0;
+	width: 15%;
 }
 .solr_active span {
-	border-top: 4px solid #ffffff !important;
-	border-left: 5px solid #999999 !important;
-	border-bottom: 4px solid #ffffff !important;
-	font-size: 0 !important;
-	line-height: 0 !important;
-	width: 0 !important;
-	margin: 0 4px 0 0 !important;
-	position: relative !important;
-	bottom: 4px !important;
-	zoom: 1 !important; /* IE7 */
+	border-top: 4px solid #ffffff;
+	border-left: 5px solid #999999;
+	border-bottom: 4px solid #ffffff;
+	font-size: 0;
+	line-height: 0;
+	width: 0;
+	margin: 0 4px 0 0;
+	position: relative;
+	bottom: 4px;
+	zoom: 1; /* IE7 */
 }
 .solr_active b {
-	font-family: Arial, Verdana, Helvetica, sans-serif !important;
-	font-weight: bold !important;
-	color: #999999 !important;
+	font-family: Arial, Verdana, Helvetica, sans-serif;
+	font-weight: bold;
+	color: #999999;
 }
 .solr_active a {
-	text-decoration: none !important;
+	text-decoration: none;
 }
 .solr_facets ol li {
-	padding: 3px 0 3px !important;
+	padding: 3px 0 3px;
 }
 .solr_facets ol li ol {
-	padding: 3px 0 0 10px !important;
+	padding: 3px 0 0 10px;
 }
 .solr_facets h3 {
-	padding: 10px 0 3px !important;
+	padding: 10px 0 3px;
 }
 .solr_active ol li {
-	padding: 3px 0 !important;
+	padding: 3px 0;
 }
 .solr_active a {
-	color: #000000 !important;
+	color: #000000;
 }
 div.solr2 {
-	float: right !important;
-	padding: 8px 0 0 !important;
-	width: 70% !important;
+	float: right;
+	width: 83%;
 }
 div.solr_results_header {
-	font-size: 10px !important;
-	color: #666666 !important;
-	padding: 0 0 4px !important;
+	font-size: 10px;
+	color: #666666;
+	padding: 0 0 4px;
 }
 div.solr_results_headerL {
-	width: 60% !important;
-	float: left !important;
-	padding: 0 0 0 12px !important;
+	width: 60%;
+	float: left;
+	padding: 5px 0 0 12px;
 }
 div.solr_results_headerR {
-	width: 35% !important;
-	font-weight: bold !important;
-	float: right !important;
+	width: 35%;
+	font-weight: bold;
+	float: right;
 }
 .solr_sort {
-	margin: 4px 4px 0 0 !important;
-	float: right !important;
+	margin: 4px 4px 0 0;
+	float: right;
 }
 ol.solr_sort2 {
-	background: #ffffff !important;
-	text-decoration: none !important;
-	border: 1px solid #cccccc !important;
-	padding: 2px 0 1px !important;
-	float: right !important;
+	background: #ffffff;
+	text-decoration: none;
+	border: 1px solid #cccccc;
+	padding: 2px 0 1px;
+	float: right;
 }
 .solr_sort2 li {
-	display: block !important; /* FF3 */
-	padding: 2px 2px 2px 4px !important;
+	display: block; /* FF3 */
+	padding: 2px 2px 2px 4px;
 }
 .solr_sort2 li:hover {
-	background: #efffb0 !important;
+	background: #efffb0;
 }
 .solr_sort2 a {
-	text-decoration: none !important;
+	text-decoration: none;
 }
 .solr_sort_drop span {
-	border-top: 4px solid #999999 !important;
-	border-right: 4px solid #ffffff !important;
-	border-left: 5px solid #ffffff !important;
-	font-size: 0 !important;
-	line-height: 0 !important;
-	width: 0 !important;
-	margin: 0 0 0 2px !important;
-	position: relative !important;
-	bottom: 1px !important;
-	zoom: 1 !important; /* IE7 */
+	border-top: 4px solid #999999;
+	border-right: 4px solid #ffffff;
+	border-left: 5px solid #ffffff;
+	font-size: 0;
+	line-height: 0;
+	width: 0;
+	margin: 0 0 0 2px;
+	position: relative;
+	bottom: 1px;
+	zoom: 1; /* IE7 */
 }
 
 .solr_results ol {
-	font-size: 12px !important;
-	padding: 0 0 14px !important;
-	clear: both !important; /* IE7 */
+	font-size: 12px;
+	padding: 0 0 14px;
+	clear: both; /* IE7 */
 }
 .solr_results li {
-	border-bottom: 1px solid #e6e6e6 !important;
-	padding: 14px 12px !important;
+	border-bottom: 1px solid #e6e6e6;
+	padding: 14px 12px;
 }
 .solr_results li:hover {
-	background: #efffb0 !important;
+	background: #efffb0;
 }
 .solr_results img {
-	height: 50px !important;
-	border: 1px solid #cccccc !important;
-	float: right !important;
+	height: 50px;
+	border: 1px solid #cccccc;
+	float: right;
 	display: block;
-	margin: 0 0 0 5px !important;
+	margin: 0 0 0 5px;
 }
 .solr_results h2 {
-	font-weight: normal !important;
-	line-height: 1.1 !important;
-	padding: 0 0 5px !important;
+	font-weight: normal;
+	line-height: 1.1;
+	padding: 0 0 5px;
 }
 .solr_results label {
-	font-size: 10px !important;
-	color: #666666 !important;
-	padding: 5px 0 0 !important;
-	display: block !important;
+	font-size: 10px;
+	color: #666666;
+	padding: 5px 0 0;
+	display: block;
 }
 .solr_pages {
-	font-size: 14px !important;
-	font-weight: bold !important;
-	text-align: right !important;
+	font-size: 14px;
+	font-weight: bold;
+	text-align: right;
 }
 .solr_pages a {
-	margin: 0 0 0 5px !important;
+	margin: 0 0 0 5px;
 }
 .solr_pages_on {
-	color: #000000 !important;
+	color: #000000;
 }
 div.solr_noresult {
-	padding: 20px 5% 40px 0 !important;
+	padding: 20px 5% 40px 0;
 }
 .solr_noresult h2 {
-	font-weight: normal !important;
-	line-height: 1.2 !important;
-	padding: 0 0 14px !important;
+	font-weight: normal;
+	line-height: 1.2;
+	padding: 0 0 14px;
 }
 .solr_noresult h3 {
-	font-weight: normal !important;
-	line-height: 1.2 !important;
-	padding: 0 0 14px !important;
+	font-weight: normal;
+	line-height: 1.2;
+	padding: 0 0 14px;
 }
 .solr_noresult p {
-	font-weight: normal !important;
-	line-height: 1.2 !important;
+	font-weight: normal;
+	line-height: 1.2;
 }
 
 
 .solr_HL {
-	background: #efffb0 !important;
+	background: #efffb0;
 }
 
 .solr_admin {


### PR DESCRIPTION
For the autocomplete, I'm simply checking that something was returned to prevent errors from showing if solr isn't setup with the terms query type or no terms were found.

For custom post types, I changed the way that they are looked up to use a wordpress function.  This allows post types without any entries to be added to the settings which is useful when setting up a new site.
