### PR TITLE
Only load s4w_options_init if 'solr-for-wordpress/solr-for-wordpress.php' is equal to $_GET['page']

### DIFF
--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1044,7 +1044,7 @@ function s4w_options_init() {
     if( !isset( $_GET['page'] ) )
         return;
 
-    if( 'solr-for-wordpress/solr-for-wordpress.php' != $_GET['page'] )
+    if( 'solr-for-wordpress/solr-for-wordpress.php' != $_GET['page'] || 'solr-for-wordpress%2Fsolr-for-wordpress.php' != $_GET['page'] )
         return;
     
     $method = $_POST['method'];

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1041,8 +1041,7 @@ function s4w_master_query($solr, $qry, $offset, $count, $fq, $sortby, &$plugin_s
 
 function s4w_options_init() {
 
-    global $pagenow;
-    if( 'solr-for-wordpress/solr-for-wordpress.php' != $pagenow )
+    if( 'solr-for-wordpress/solr-for-wordpress.php' != $_GET['page'] )
         return;
     
     $method = $_POST['method'];

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1041,6 +1041,9 @@ function s4w_master_query($solr, $qry, $offset, $count, $fq, $sortby, &$plugin_s
 
 function s4w_options_init() {
 
+    if( !isset( $_GET['page'] ) )
+        return;
+
     if( 'solr-for-wordpress/solr-for-wordpress.php' != $_GET['page'] )
         return;
     

--- a/solr-for-wordpress.php
+++ b/solr-for-wordpress.php
@@ -1040,6 +1040,10 @@ function s4w_master_query($solr, $qry, $offset, $count, $fq, $sortby, &$plugin_s
 }
 
 function s4w_options_init() {
+
+    global $pagenow;
+    if( 'solr-for-wordpress/solr-for-wordpress.php' != $pagenow )
+        return;
     
     $method = $_POST['method'];
     if ($method === "load") {


### PR DESCRIPTION
's4w_options_init' action will only trigger on the solr options page. The function still immediately looks for $_GET['method'], which on 'init' will be null.
